### PR TITLE
Add initial .NET MAUI project skeleton

### DIFF
--- a/SlimsteMens.Maui/App.xaml
+++ b/SlimsteMens.Maui/App.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="SlimsteMens.Maui.App">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
+                <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/SlimsteMens.Maui/App.xaml.cs
+++ b/SlimsteMens.Maui/App.xaml.cs
@@ -1,0 +1,12 @@
+using Microsoft.Maui.Controls;
+
+namespace SlimsteMens.Maui;
+
+public partial class App : Application
+{
+    public App()
+    {
+        InitializeComponent();
+        MainPage = new NavigationPage(new Pages.PresenterPage());
+    }
+}

--- a/SlimsteMens.Maui/CLAUDE_MAUI.md
+++ b/SlimsteMens.Maui/CLAUDE_MAUI.md
@@ -1,0 +1,54 @@
+Je bent een senior .NET developer. Gebruik onderstaand projectplan (CLAUDE_MAUI.md) als strikte blauwdruk. Genereer een complete **.NET MAUI (.NET 9, Single Project)** applicatie in C#.
+
+### Doel
+- Twee vensters: PresenterWindow (primair) en AudienceWindow (fullscreen 2e scherm).
+- Functies: rondes, vragen, scorebord, finale-logica, media-sync.
+- Editor: CRUD rondes/vragen/opties, JSON save/load.
+- Styling: look & feel van *De Slimste Mens* (donkere achtergrond, witte typografie, gouden accenten).
+
+### Vereisten
+- MVVM met **CommunityToolkit.Mvvm**
+- **CommunityToolkit.Maui** + **CommunityToolkit.Maui.MediaElement**
+- JSON opslag via **System.Text.Json**
+- Services: `GameRepository`, `DisplayService`, `MediaSyncService`
+- ViewModels: `PresenterViewModel`, `AudienceViewModel`, `EditorViewModel`, `ScoreboardViewModel`
+- Data: `Data/game.sample.json` en `schema.md`
+- Hotkeys (Windows): ←/→, 1–8, Space, Enter, S/D, F11
+
+### Projectstructuur
+```
+SlimsteMens.Maui/
+├─ App.xaml
+├─ MauiProgram.cs
+├─ Resources/Styles/{Colors.xaml, Styles.xaml}
+├─ Models/{Game.cs, Round.cs, Question.cs, AnswerOption.cs, Team.cs, Enums.cs}
+├─ Services/{GameRepository.cs, DisplayService.cs, MediaSyncService.cs}
+├─ ViewModels/{BaseViewModel.cs, PresenterViewModel.cs, AudienceViewModel.cs, EditorViewModel.cs, ScoreboardViewModel.cs}
+├─ Pages/{PresenterPage.xaml, AudiencePage.xaml, EditorPage.xaml, ScoreboardPage.xaml, FinalePage.xaml}
+├─ Windows/{PresenterWindow.cs, AudienceWindow.cs}
+├─ Platforms/
+│  ├─ Windows/DisplayService.Windows.cs
+│  ├─ Android/DisplayService.Android.cs (placeholder)
+│  └─ iOS/DisplayService.iOS.cs (placeholder)
+└─ Data/{game.sample.json, schema.md}
+```
+
+### Belangrijkste implementaties
+1. **DisplayService** – multi-window en fullscreen op 2e scherm (Windows interop via `AppWindow`).
+2. **MediaSyncService** – sync van Play/Pause/Position voor MediaElement.
+3. **ViewModels** – Presenter: navigatie, timer, reveal; Audience: alleen lezen; Editor: CRUD; Scoreboard: secondenbeheer.
+4. **Styling** – donkere achtergrond (#0B0C10), witte tekst (#FFFFFF), accent goud (#FFD700).
+5. **Finale** – ronde klok (GraphicsView of ProgressBar) + ±10 seconden knoppen.
+6. **Hotkeys** – via Windows-specifieke events.
+
+### Output
+- Volledige MAUI solution met bovengenoemde structuur.
+- Compileerbaar en uitvoerbaar op Windows.
+- AudienceWindow automatisch fullscreen op 2e scherm (fallback: gemaximaliseerd).
+- Werkende demo met 2 rondes (3-6-9 + Open Deur).
+
+### Runnen in Rider
+1. Open de solution (`.sln`).
+2. Zorg dat .NET 9 SDK en MAUI workloads geïnstalleerd zijn (`dotnet workload install maui`).
+3. Kies Run Configuration: *Windows Machine* (SlimsteMens.Maui).
+4. Run (Shift+F10). PresenterWindow opent primair; AudienceWindow fullscreen op 2e scherm.

--- a/SlimsteMens.Maui/Data/game.sample.json
+++ b/SlimsteMens.Maui/Data/game.sample.json
@@ -1,0 +1,25 @@
+{
+  "Rounds": [
+    {
+      "Title": "3-6-9",
+      "Questions": [
+        {
+          "Text": "Wat is 3?",
+          "Options": [
+            { "Text": "Drie", "IsCorrect": true },
+            { "Text": "Vier", "IsCorrect": false }
+          ],
+          "CorrectIndex": 0
+        }
+      ]
+    },
+    {
+      "Title": "Open Deur",
+      "Questions": []
+    }
+  ],
+  "Teams": [
+    { "Name": "Team A", "Seconds": 60 },
+    { "Name": "Team B", "Seconds": 60 }
+  ]
+}

--- a/SlimsteMens.Maui/Data/schema.md
+++ b/SlimsteMens.Maui/Data/schema.md
@@ -1,0 +1,12 @@
+# Game JSON Schema
+- `Rounds`: array of rounds
+  - `Title`: string
+  - `Questions`: array of questions
+    - `Text`: string
+    - `Options`: array of answer options
+      - `Text`: string
+      - `IsCorrect`: bool
+    - `CorrectIndex`: int
+- `Teams`: array of teams
+  - `Name`: string
+  - `Seconds`: int

--- a/SlimsteMens.Maui/MauiProgram.cs
+++ b/SlimsteMens.Maui/MauiProgram.cs
@@ -1,0 +1,19 @@
+using CommunityToolkit.Maui;
+using Microsoft.Maui.Controls.Hosting;
+using Microsoft.Maui.Hosting;
+
+namespace SlimsteMens.Maui;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiApp<App>()
+            .UseMauiCommunityToolkit()
+            .UseMauiCommunityToolkitMediaElement();
+
+        return builder.Build();
+    }
+}

--- a/SlimsteMens.Maui/Models/AnswerOption.cs
+++ b/SlimsteMens.Maui/Models/AnswerOption.cs
@@ -1,0 +1,7 @@
+namespace SlimsteMens.Maui.Models;
+
+public class AnswerOption
+{
+    public string Text { get; set; } = string.Empty;
+    public bool IsCorrect { get; set; }
+}

--- a/SlimsteMens.Maui/Models/Enums.cs
+++ b/SlimsteMens.Maui/Models/Enums.cs
@@ -1,0 +1,8 @@
+namespace SlimsteMens.Maui.Models;
+
+public enum RoundType
+{
+    ThreeSixNine,
+    OpenDoor,
+    Finale
+}

--- a/SlimsteMens.Maui/Models/Game.cs
+++ b/SlimsteMens.Maui/Models/Game.cs
@@ -1,0 +1,7 @@
+namespace SlimsteMens.Maui.Models;
+
+public class Game
+{
+    public List<Round> Rounds { get; set; } = new();
+    public List<Team> Teams { get; set; } = new();
+}

--- a/SlimsteMens.Maui/Models/Question.cs
+++ b/SlimsteMens.Maui/Models/Question.cs
@@ -1,0 +1,8 @@
+namespace SlimsteMens.Maui.Models;
+
+public class Question
+{
+    public string Text { get; set; } = string.Empty;
+    public List<AnswerOption> Options { get; set; } = new();
+    public int CorrectIndex { get; set; }
+}

--- a/SlimsteMens.Maui/Models/Round.cs
+++ b/SlimsteMens.Maui/Models/Round.cs
@@ -1,0 +1,7 @@
+namespace SlimsteMens.Maui.Models;
+
+public class Round
+{
+    public string Title { get; set; } = string.Empty;
+    public List<Question> Questions { get; set; } = new();
+}

--- a/SlimsteMens.Maui/Models/Team.cs
+++ b/SlimsteMens.Maui/Models/Team.cs
@@ -1,0 +1,7 @@
+namespace SlimsteMens.Maui.Models;
+
+public class Team
+{
+    public string Name { get; set; } = string.Empty;
+    public int Seconds { get; set; }
+}

--- a/SlimsteMens.Maui/Pages/AudiencePage.xaml
+++ b/SlimsteMens.Maui/Pages/AudiencePage.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewmodels="clr-namespace:SlimsteMens.Maui.ViewModels"
+             x:Class="SlimsteMens.Maui.Pages.AudiencePage">
+    <ContentPage.BindingContext>
+        <viewmodels:AudienceViewModel />
+    </ContentPage.BindingContext>
+    <StackLayout Padding="20" Spacing="20">
+        <Label Text="Audience" FontSize="32" />
+    </StackLayout>
+</ContentPage>

--- a/SlimsteMens.Maui/Pages/AudiencePage.xaml.cs
+++ b/SlimsteMens.Maui/Pages/AudiencePage.xaml.cs
@@ -1,0 +1,9 @@
+namespace SlimsteMens.Maui.Pages;
+
+public partial class AudiencePage : ContentPage
+{
+    public AudiencePage()
+    {
+        InitializeComponent();
+    }
+}

--- a/SlimsteMens.Maui/Pages/EditorPage.xaml
+++ b/SlimsteMens.Maui/Pages/EditorPage.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewmodels="clr-namespace:SlimsteMens.Maui.ViewModels"
+             x:Class="SlimsteMens.Maui.Pages.EditorPage">
+    <ContentPage.BindingContext>
+        <viewmodels:EditorViewModel />
+    </ContentPage.BindingContext>
+    <StackLayout Padding="20" Spacing="20">
+        <Label Text="Editor" FontSize="32" />
+        <Button Text="Save" Command="{Binding SaveAsyncCommand}" />
+    </StackLayout>
+</ContentPage>

--- a/SlimsteMens.Maui/Pages/EditorPage.xaml.cs
+++ b/SlimsteMens.Maui/Pages/EditorPage.xaml.cs
@@ -1,0 +1,9 @@
+namespace SlimsteMens.Maui.Pages;
+
+public partial class EditorPage : ContentPage
+{
+    public EditorPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/SlimsteMens.Maui/Pages/FinalePage.xaml
+++ b/SlimsteMens.Maui/Pages/FinalePage.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="SlimsteMens.Maui.Pages.FinalePage">
+    <StackLayout Padding="20" Spacing="20">
+        <Label Text="Finale" FontSize="32" />
+    </StackLayout>
+</ContentPage>

--- a/SlimsteMens.Maui/Pages/FinalePage.xaml.cs
+++ b/SlimsteMens.Maui/Pages/FinalePage.xaml.cs
@@ -1,0 +1,9 @@
+namespace SlimsteMens.Maui.Pages;
+
+public partial class FinalePage : ContentPage
+{
+    public FinalePage()
+    {
+        InitializeComponent();
+    }
+}

--- a/SlimsteMens.Maui/Pages/PresenterPage.xaml
+++ b/SlimsteMens.Maui/Pages/PresenterPage.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewmodels="clr-namespace:SlimsteMens.Maui.ViewModels"
+             x:Class="SlimsteMens.Maui.Pages.PresenterPage">
+    <ContentPage.BindingContext>
+        <viewmodels:PresenterViewModel />
+    </ContentPage.BindingContext>
+    <StackLayout Padding="20" Spacing="20">
+        <Label Text="Presenter" FontSize="32" />
+        <Button Text="Load Game" Command="{Binding LoadGameAsyncCommand}" />
+        <Button Text="Show Audience" Command="{Binding ShowAudienceCommand}" />
+    </StackLayout>
+</ContentPage>

--- a/SlimsteMens.Maui/Pages/PresenterPage.xaml.cs
+++ b/SlimsteMens.Maui/Pages/PresenterPage.xaml.cs
@@ -1,0 +1,11 @@
+using SlimsteMens.Maui.ViewModels;
+
+namespace SlimsteMens.Maui.Pages;
+
+public partial class PresenterPage : ContentPage
+{
+    public PresenterPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/SlimsteMens.Maui/Pages/ScoreboardPage.xaml
+++ b/SlimsteMens.Maui/Pages/ScoreboardPage.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewmodels="clr-namespace:SlimsteMens.Maui.ViewModels"
+             x:Class="SlimsteMens.Maui.Pages.ScoreboardPage">
+    <ContentPage.BindingContext>
+        <viewmodels:ScoreboardViewModel />
+    </ContentPage.BindingContext>
+    <StackLayout Padding="20" Spacing="20">
+        <Label Text="Scoreboard" FontSize="32" />
+    </StackLayout>
+</ContentPage>

--- a/SlimsteMens.Maui/Pages/ScoreboardPage.xaml.cs
+++ b/SlimsteMens.Maui/Pages/ScoreboardPage.xaml.cs
@@ -1,0 +1,9 @@
+namespace SlimsteMens.Maui.Pages;
+
+public partial class ScoreboardPage : ContentPage
+{
+    public ScoreboardPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/SlimsteMens.Maui/Platforms/Android/DisplayService.Android.cs
+++ b/SlimsteMens.Maui/Platforms/Android/DisplayService.Android.cs
@@ -1,0 +1,9 @@
+namespace SlimsteMens.Maui.Services;
+
+public partial class DisplayService
+{
+    public partial void ShowAudienceWindow()
+    {
+        // TODO: implement multi-window on Android
+    }
+}

--- a/SlimsteMens.Maui/Platforms/Windows/DisplayService.Windows.cs
+++ b/SlimsteMens.Maui/Platforms/Windows/DisplayService.Windows.cs
@@ -1,0 +1,18 @@
+using Microsoft.UI;
+using Microsoft.UI.Windowing;
+using SlimsteMens.Maui.Windows;
+
+namespace SlimsteMens.Maui.Services;
+
+public partial class DisplayService
+{
+    public partial void ShowAudienceWindow()
+    {
+        var window = new AudienceWindow();
+        window.Activate();
+        if (AppWindow.TryGetFromWindowId(Win32Interop.GetWindowIdFromWindow(window.GetWindowHandle()), out var appWindow))
+        {
+            appWindow.SetPresenter(AppWindowPresenterKind.FullScreen);
+        }
+    }
+}

--- a/SlimsteMens.Maui/Platforms/iOS/DisplayService.iOS.cs
+++ b/SlimsteMens.Maui/Platforms/iOS/DisplayService.iOS.cs
@@ -1,0 +1,9 @@
+namespace SlimsteMens.Maui.Services;
+
+public partial class DisplayService
+{
+    public partial void ShowAudienceWindow()
+    {
+        // TODO: implement multi-window on iOS
+    }
+}

--- a/SlimsteMens.Maui/README.md
+++ b/SlimsteMens.Maui/README.md
@@ -1,0 +1,15 @@
+# SlimsteMens.Maui
+
+Een eenvoudige .NET MAUI demo gebaseerd op het tv-programma *De Slimste Mens*.
+
+## Benodigdheden
+- .NET 9 SDK
+- MAUI workload (`dotnet workload install maui`)
+
+## Bouwen
+```
+dotnet build
+```
+
+## Starten
+Open de solution in Rider en start het `SlimsteMens.Maui` project voor Windows.

--- a/SlimsteMens.Maui/Resources/Styles/Colors.xaml
+++ b/SlimsteMens.Maui/Resources/Styles/Colors.xaml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <Color x:Key="DarkBackground">#0B0C10</Color>
+    <Color x:Key="LightText">#FFFFFF</Color>
+    <Color x:Key="GoldAccent">#FFD700</Color>
+</ResourceDictionary>

--- a/SlimsteMens.Maui/Resources/Styles/Styles.xaml
+++ b/SlimsteMens.Maui/Resources/Styles/Styles.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <Style TargetType="ContentPage">
+        <Setter Property="BackgroundColor" Value="{StaticResource DarkBackground}" />
+    </Style>
+    <Style TargetType="Label">
+        <Setter Property="TextColor" Value="{StaticResource LightText}" />
+        <Setter Property="FontSize" Value="24" />
+    </Style>
+    <Style TargetType="Button">
+        <Setter Property="BackgroundColor" Value="{StaticResource GoldAccent}" />
+        <Setter Property="TextColor" Value="{StaticResource DarkBackground}" />
+    </Style>
+</ResourceDictionary>

--- a/SlimsteMens.Maui/Services/DisplayService.cs
+++ b/SlimsteMens.Maui/Services/DisplayService.cs
@@ -1,0 +1,6 @@
+namespace SlimsteMens.Maui.Services;
+
+public partial class DisplayService
+{
+    public partial void ShowAudienceWindow();
+}

--- a/SlimsteMens.Maui/Services/GameRepository.cs
+++ b/SlimsteMens.Maui/Services/GameRepository.cs
@@ -1,0 +1,22 @@
+using System.Text.Json;
+using SlimsteMens.Maui.Models;
+
+namespace SlimsteMens.Maui.Services;
+
+public class GameRepository
+{
+    const string SamplePath = "Data/game.sample.json";
+
+    public async Task<Game?> LoadAsync(string path = SamplePath)
+    {
+        if (!File.Exists(path)) return null;
+        using var stream = File.OpenRead(path);
+        return await JsonSerializer.DeserializeAsync<Game>(stream);
+    }
+
+    public async Task SaveAsync(Game game, string path = SamplePath)
+    {
+        using var stream = File.Create(path);
+        await JsonSerializer.SerializeAsync(stream, game, new JsonSerializerOptions { WriteIndented = true });
+    }
+}

--- a/SlimsteMens.Maui/Services/MediaSyncService.cs
+++ b/SlimsteMens.Maui/Services/MediaSyncService.cs
@@ -1,0 +1,8 @@
+namespace SlimsteMens.Maui.Services;
+
+public class MediaSyncService
+{
+    public string? MediaPath { get; set; }
+    public bool IsPlaying { get; set; }
+    public TimeSpan Position { get; set; }
+}

--- a/SlimsteMens.Maui/SlimsteMens.Maui.csproj
+++ b/SlimsteMens.Maui/SlimsteMens.Maui.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Maui" Version="8.0.0" />
+    <PackageReference Include="CommunityToolkit.Maui.MediaElement" Version="8.0.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <MauiAsset Include="Resources\**" />
+    <MauiFont Include="Resources\Fonts\*" Alias="*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Data/game.sample.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/SlimsteMens.Maui/ViewModels/AudienceViewModel.cs
+++ b/SlimsteMens.Maui/ViewModels/AudienceViewModel.cs
@@ -1,0 +1,8 @@
+using SlimsteMens.Maui.Models;
+
+namespace SlimsteMens.Maui.ViewModels;
+
+public partial class AudienceViewModel : BaseViewModel
+{
+    public Game? Game { get; set; }
+}

--- a/SlimsteMens.Maui/ViewModels/BaseViewModel.cs
+++ b/SlimsteMens.Maui/ViewModels/BaseViewModel.cs
@@ -1,0 +1,7 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SlimsteMens.Maui.ViewModels;
+
+public partial class BaseViewModel : ObservableObject
+{
+}

--- a/SlimsteMens.Maui/ViewModels/EditorViewModel.cs
+++ b/SlimsteMens.Maui/ViewModels/EditorViewModel.cs
@@ -1,0 +1,19 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using SlimsteMens.Maui.Models;
+using SlimsteMens.Maui.Services;
+
+namespace SlimsteMens.Maui.ViewModels;
+
+public partial class EditorViewModel : BaseViewModel
+{
+    readonly GameRepository _repository;
+
+    [ObservableProperty]
+    Game game = new();
+
+    public EditorViewModel(GameRepository repository) => _repository = repository;
+
+    [RelayCommand]
+    public async Task SaveAsync() => await _repository.SaveAsync(Game);
+}

--- a/SlimsteMens.Maui/ViewModels/PresenterViewModel.cs
+++ b/SlimsteMens.Maui/ViewModels/PresenterViewModel.cs
@@ -1,0 +1,27 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using SlimsteMens.Maui.Models;
+using SlimsteMens.Maui.Services;
+
+namespace SlimsteMens.Maui.ViewModels;
+
+public partial class PresenterViewModel : BaseViewModel
+{
+    readonly GameRepository _repository;
+    readonly DisplayService _displayService;
+
+    [ObservableProperty]
+    Game? game;
+
+    public PresenterViewModel(GameRepository repository, DisplayService displayService)
+    {
+        _repository = repository;
+        _displayService = displayService;
+    }
+
+    [RelayCommand]
+    public async Task LoadGameAsync() => Game = await _repository.LoadAsync();
+
+    [RelayCommand]
+    public void ShowAudience() => _displayService.ShowAudienceWindow();
+}

--- a/SlimsteMens.Maui/ViewModels/ScoreboardViewModel.cs
+++ b/SlimsteMens.Maui/ViewModels/ScoreboardViewModel.cs
@@ -1,0 +1,22 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using SlimsteMens.Maui.Models;
+
+namespace SlimsteMens.Maui.ViewModels;
+
+public partial class ScoreboardViewModel : BaseViewModel
+{
+    [ObservableProperty]
+    public partial Team? ActiveTeam { get; set; }
+
+    public ObservableCollection<Team> Teams { get; } = new();
+
+    [RelayCommand]
+    void AddSeconds(int seconds)
+    {
+        if (ActiveTeam is null) return;
+        ActiveTeam.Seconds += seconds;
+        OnPropertyChanged(nameof(Teams));
+    }
+}

--- a/SlimsteMens.Maui/Windows/AudienceWindow.cs
+++ b/SlimsteMens.Maui/Windows/AudienceWindow.cs
@@ -1,0 +1,9 @@
+namespace SlimsteMens.Maui.Windows;
+
+public class AudienceWindow : Window
+{
+    public AudienceWindow() : base(new Pages.AudiencePage())
+    {
+        Title = "Audience";
+    }
+}

--- a/SlimsteMens.Maui/Windows/PresenterWindow.cs
+++ b/SlimsteMens.Maui/Windows/PresenterWindow.cs
@@ -1,0 +1,9 @@
+namespace SlimsteMens.Maui.Windows;
+
+public class PresenterWindow : Window
+{
+    public PresenterWindow() : base(new Pages.PresenterPage())
+    {
+        Title = "Presenter";
+    }
+}

--- a/SlimsteMens.sln
+++ b/SlimsteMens.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlimsteMens.Maui", "SlimsteMens.Maui\SlimsteMens.Maui.csproj", "{CE64C9F3-5770-4CA1-8B36-649638E248B3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CE64C9F3-5770-4CA1-8B36-649638E248B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE64C9F3-5770-4CA1-8B36-649638E248B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE64C9F3-5770-4CA1-8B36-649638E248B3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CE64C9F3-5770-4CA1-8B36-649638E248B3}.Debug|x64.Build.0 = Debug|Any CPU
+		{CE64C9F3-5770-4CA1-8B36-649638E248B3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CE64C9F3-5770-4CA1-8B36-649638E248B3}.Debug|x86.Build.0 = Debug|Any CPU
+		{CE64C9F3-5770-4CA1-8B36-649638E248B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE64C9F3-5770-4CA1-8B36-649638E248B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE64C9F3-5770-4CA1-8B36-649638E248B3}.Release|x64.ActiveCfg = Release|Any CPU
+		{CE64C9F3-5770-4CA1-8B36-649638E248B3}.Release|x64.Build.0 = Release|Any CPU
+		{CE64C9F3-5770-4CA1-8B36-649638E248B3}.Release|x86.ActiveCfg = Release|Any CPU
+		{CE64C9F3-5770-4CA1-8B36-649638E248B3}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- scaffold .NET MAUI solution targeting .NET 9
- add models, services, viewmodels, and pages for presenter and audience windows
- include sample game data and project documentation

## Testing
- `dotnet build SlimsteMens.sln` *(fails: workload maui-android missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a871035cc48327b08d8a860d27bd6d